### PR TITLE
DEV-9184 Compare IEC 62683 to IDM

### DIFF
--- a/iec-62683.md
+++ b/iec-62683.md
@@ -1,0 +1,217 @@
+# IEC 62683 to IDM comparison
+
+This document compares the product attributes defined by IEC 62683 (Low-voltage switchgear and
+controlgear: product data and properties for information exchange) against the Interoperability
+Data Model (IDM) in this repository.
+
+Note on the IDM keys:
+The dot-separated keys below are aligned to the rebuilt schema in PR #6
+(branch `dev-9183-sync-interoperability-data-model-to-dcide-app-validators`), not to the older
+schema on `main`. PR #6 is still in review, so if it changes the keys here may need a refresh.
+
+Note on coverage:
+IEC 62683 is paywalled. The attribute list below is compiled from the public IEC 62683-1 preview
+(scope, the block library in Table 1, and the device class hierarchy in Table 2) plus the property
+base it normatively references in IEC 60947-1 and IEC 60947-2. Where an attribute could not be
+confirmed as part of the standard it has been left out rather than invented. The standard's full
+per-class property tables (for example Table 3 Circuit-breaker) sit behind the paywall, so the
+property names below are the well-established IEC 60947 terms that those tables draw from.
+
+Note on scope:
+IEC 62683 covers the whole low-voltage switchgear and controlgear domain (circuit-breakers,
+switch-disconnectors, fuses, contactors, starters, control switches, terminal blocks and more).
+This comparison centres on the circuit-breaker class as the representative switching device, since
+it carries the richest property set and the IDM models it directly. Properties that are shared
+across switching devices (identification, ratings, connection, mounting, environmental, standards)
+apply to the contactor, disconnect and fuse classes too. A short fuse-specific and
+contactor/disconnect-specific section follows at the end.
+
+Note on the IDM port model:
+In the rebuilt IDM a switching device has two ports (line side and load side) kept in sync, so
+`electrical.ports[0]` and `electrical.ports[1]` carry identical values. Keys are written as
+`electrical.ports[].AC.*` to mean both. Each port carries an `AC` block and a `DC` block; the AC
+path is shown for brevity and the matching `DC` path exists where the field is present in both.
+
+## Section 1: IEC 62683 attributes
+
+The standard groups properties into blocks (IEC 62683-1 Table 1). The grouping below follows those
+blocks, mapped to the familiar identification / ratings / electrical / mechanical / environmental
+view.
+
+### Identification (block ACC011)
+
+- Manufacturer name
+- Type or catalogue designation (manufacturer part number)
+- Product series or family name
+- Product description
+- GTIN or EAN article number
+- Product website or catalogue reference
+
+### General technical data (block ACC012)
+
+- Rated frequency
+- Number of poles
+- Suitability for isolation
+- Pollution degree
+- Overvoltage category
+- Utilization category (for example A or B)
+- Tripping characteristic (trip curve type)
+- Circuit-breaker construction type (for example MCB, MCCB, ACB)
+- Current type suitability (AC, DC or both)
+- Mechanical durability (number of operating cycles)
+- Electrical durability (number of operating cycles)
+- Power dissipation per pole
+
+### Main circuit ratings (blocks ACC014, ACC040)
+
+- Rated operational voltage (Ue)
+- Rated insulation voltage (Ui)
+- Rated impulse withstand voltage (Uimp)
+- Rated current or rated uninterrupted current (In, Iu)
+- Rated operational current (Ie)
+- Rated voltage per pole
+- Total rated voltage
+- Rated ultimate short-circuit breaking capacity (Icu)
+- Rated service short-circuit breaking capacity (Ics)
+- Rated short-circuit making capacity (Icm)
+- Rated short-time withstand current (Icw)
+- Instantaneous short-circuit current rating (UL)
+
+### Over-current and residual current release (blocks ACC041, ACC203)
+
+- Type of over-current release (thermomagnetic or electronic)
+- Rated current of the release or trip unit setting
+- Overload (thermal) trip setting range
+- Instantaneous (magnetic) trip current
+- Residual current device present
+- Rated residual operating current (I delta n)
+- Residual current trip level
+
+### Connection facilities (block ACC068)
+
+- Type of terminal or connection
+- Connectable conductor cross-section (minimum and maximum)
+- Terminal tightening torque
+
+### Installation, mounting and dimensions (block ACC066)
+
+- Mounting type (for example DIN rail, panel)
+- Width
+- Height
+- Depth or length
+- Weight
+- Degree of protection (IP code)
+
+### Environmental and operating conditions
+
+- Operating ambient temperature (minimum and maximum)
+- Storage temperature (minimum and maximum)
+- Relative humidity range
+- Maximum operating altitude
+
+### Data communication (block ACC050)
+
+- Communication interfaces
+- Communication protocols
+
+### Product certificates and standards (block ACC070)
+
+- Product standards complied with
+- CE marking
+- UL listing or recognition
+
+## Section 2: Mapping to IDM keys
+
+Keys are derived from the PR #6 rebuilt `breaker` schema (see `docs/breaker.md`, `docs/common.md`
+and `examples/testBreaker.json` on the PR #6 branch). `(no IDM equivalent)` marks a gap.
+
+| IEC 62683 Attribute | Description | IDM key (dot-separated) |
+| --- | --- | --- |
+| Manufacturer name | Reference to the manufacturer | `manufacturer` |
+| Type or catalogue designation | Manufacturer part number or SKU | `productIdentifier` |
+| Product series name | Product family or series | `productSeries` |
+| Product name | Human readable product name | `name` |
+| Product description | Free text description | `description` |
+| GTIN or EAN | Global trade article number | `(no IDM equivalent)` |
+| Product website | Product page URL | `website` |
+| Rated frequency | Nominal AC supply frequency | `electrical.ports[].AC.frequency.nom` |
+| Number of poles | Pole configuration of the device | `electrical.ports[].AC.poles` |
+| Suitability for isolation | Whether the device provides isolation | `(no IDM equivalent)` |
+| Pollution degree | Rated pollution degree of the environment | `(no IDM equivalent)` |
+| Overvoltage category | Rated overvoltage category | `electrical.ports[].overvoltageCategory` |
+| Utilization category | Duty class (for example A or B) | `(no IDM equivalent)` |
+| Tripping characteristic | Trip curve class (for example B, C, D) | `electrical.ports[].tripCurve` |
+| Construction type | MCB, MCCB, SSCB or ACB | `electrical.breakerType` |
+| Current type suitability (AC) | Whether the AC block is usable | `electrical.ports[].AC.enabled` |
+| Current type suitability (DC) | Whether the DC block is usable | `electrical.ports[].DC.enabled` |
+| Mechanical durability | Number of mechanical operating cycles | `(no IDM equivalent)` |
+| Electrical durability | Number of electrical operating cycles | `(no IDM equivalent)` |
+| Power dissipation per pole | Power loss of the device | `performance.losses.nom` |
+| Rated operational voltage (Ue) | Nominal AC operating voltage | `electrical.ports[].AC.voltage.nom` |
+| Rated insulation voltage (Ui) | Rated isolation voltage | `electrical.isolationVoltage.value` |
+| Rated impulse withstand voltage (Uimp) | Rated impulse withstand voltage | `(no IDM equivalent)` |
+| Rated current (In, Iu) | Nominal rated current | `electrical.ports[].AC.current.nom` |
+| Rated operational current (Ie) | Operational current at the rated voltage | `electrical.ports[].AC.current.nom` |
+| Rated voltage per pole | Rated voltage per pole | `electrical.ports[].AC.voltagePerPole.value` |
+| Total rated voltage | Total rated voltage across poles | `electrical.ports[].AC.totalVoltage.value` |
+| Rated ultimate short-circuit breaking capacity (Icu) | IEC ultimate breaking capacity | `electrical.ports[].AC.ultimateShortCircuitBreakingCapacityIEC.value` |
+| Rated service short-circuit breaking capacity (Ics) | IEC service breaking capacity | `electrical.ports[].AC.serviceShortCircuitBreakingCapacityIEC.value` |
+| Rated short-circuit making capacity (Icm) | Peak make capability | `(no IDM equivalent)` |
+| Rated short-time withstand current (Icw) | Withstand current for a stated time | `(no IDM equivalent)` |
+| Instantaneous short-circuit current (UL) | UL instantaneous short-circuit current | `electrical.ports[].AC.instantaneousShortCircuitCurrentUL.value` |
+| Critical clearing time | Time to clear the fault | `electrical.ports[].AC.criticalClearingTime.value` |
+| Type of over-current release | Thermomagnetic or electronic trip unit | `(no IDM equivalent)` |
+| Rated current of the release | Trip unit rated current or setting | `electrical.ports[].AC.current.nom` |
+| Overload trip setting range | Adjustable thermal trip range | `(no IDM equivalent)` |
+| Instantaneous trip current | Magnetic trip threshold | `(no IDM equivalent)` |
+| Residual current device present | Whether an RCD is integrated | `electrical.residualCurrentDevice.enabled` |
+| Rated residual operating current | RCD rated residual operating current | `electrical.residualCurrentDevice.ratedResidualOperatingCurrent.value` |
+| Residual current trip level | Per port RCD trip level | `electrical.ports[].residualCurrentDeviceTripLevel.value` |
+| Type of terminal or connection | Terminal type (lug or screw) | `electrical.ports[].terminal.type` |
+| Connectable conductor cross-section (min) | Smallest wire size accepted | `electrical.ports[].wireSize.min` |
+| Connectable conductor cross-section (max) | Largest wire size accepted | `electrical.ports[].wireSize.max` |
+| Terminal tightening torque | Recommended terminal torque | `electrical.ports[].terminal.torque.nom` |
+| Mounting type | DIN rail, panel, wall, floor or rack | `mechanical.mountingType` |
+| Width | Device width | `mechanical.dimensions.width` |
+| Height | Device height | `mechanical.dimensions.height` |
+| Depth or length | Device length | `mechanical.dimensions.length` |
+| Weight | Device weight | `mechanical.weight.value` |
+| Degree of protection (IP code) | IP enclosure rating | `environmental.ingressProtection_IP` |
+| Operating ambient temperature (min) | Minimum operating temperature | `environmental.operatingTemperature.min` |
+| Operating ambient temperature (max) | Maximum operating temperature | `environmental.operatingTemperature.max` |
+| Storage temperature (min) | Minimum storage temperature | `environmental.storageTemperature.min` |
+| Storage temperature (max) | Maximum storage temperature | `environmental.storageTemperature.max` |
+| Relative humidity range | Operating humidity range | `environmental.operatingHumidity.min` |
+| Maximum operating altitude | Highest rated installation altitude | `environmental.maximumOperatingAltitude.value` |
+| Communication interfaces | Supported electrical interfaces | `communication.interfaces` |
+| Communication protocols | Supported communication protocols | `communication.protocols` |
+| Product standards complied with | Standards the product meets | `standards` |
+| CE marking | CE compliance flag | `compliance.CE` |
+| UL listing | UL compliance flag | `compliance.UL` |
+
+### Fuse-specific attributes
+
+These apply to the IEC 62683 fuse and fuse-switch-disconnector classes and map to the IDM `fuse`
+schema on the PR #6 branch (see `docs/fuse.md`).
+
+| IEC 62683 Attribute | Description | IDM key (dot-separated) |
+| --- | --- | --- |
+| Melting I squared t | Pre-arcing let-through energy | `electrical.meltingI2t.value` |
+| Arcing I squared t | Arcing let-through energy | `electrical.arcingI2t.value` |
+| Total clearing I squared t | Total let-through energy | `electrical.totalClearingI2t.value` |
+| Minimum breaking capacity | Lowest current the fuse can interrupt | `electrical.ports[].AC.minimumBreakingCapacity.value` |
+| Maximum time constant (DC) | Rated circuit time constant | `electrical.ports[].DC.maximumTimeConstant.value` |
+| Number of poles | Number of poles of the fuse | `electrical.ports[].numberOfPoles` |
+
+### Contactor and switch-disconnector specific attributes
+
+These apply to the IEC 62683 contactor and switch-disconnector classes and map to the IDM
+`contactor` and `disconnect` schemas on the PR #6 branch (see `docs/contactor.md`,
+`docs/disconnect.md`).
+
+| IEC 62683 Attribute | Description | IDM key (dot-separated) |
+| --- | --- | --- |
+| Auxiliary feedback signal | Auxiliary or feedback contact present | `electrical.features.feedbackSignal` |
+| Integrated fuse (switch-disconnector) | Whether an integrated fuse is present | `electrical.features.fuse` |
+| Rated insulation voltage | Rated isolation voltage | `electrical.isolationVoltage.value` |
+| Control method | Supported control strategy | `electrical.ports[].AC.controlMethods` |

--- a/iec-62683.md
+++ b/iec-62683.md
@@ -152,7 +152,7 @@ and `examples/testBreaker.json` on the PR #6 branch). `(no IDM equivalent)` mark
 | Rated impulse withstand voltage (Uimp) | Rated impulse withstand voltage | `(no IDM equivalent)` |
 | Rated current (In, Iu) | Nominal rated current | `electrical.ports[].AC.current.nom` |
 | Rated operational current (Ie) | Operational current at the rated voltage | `electrical.ports[].AC.current.nom` |
-| Rated voltage per pole | Rated voltage per pole | `electrical.ports[].AC.voltagePerPole.value` |
+| Rated voltage per pole | Rated voltage per pole. The IDM `voltagePerPole` field is gated to DC (per pole, bipolar DC concept), so it does not represent this AC switchgear attribute. | `(no IDM equivalent)` |
 | Total rated voltage | Total rated voltage across poles | `electrical.ports[].AC.totalVoltage.value` |
 | Rated ultimate short-circuit breaking capacity (Icu) | IEC ultimate breaking capacity | `electrical.ports[].AC.ultimateShortCircuitBreakingCapacityIEC.value` |
 | Rated service short-circuit breaking capacity (Ics) | IEC service breaking capacity | `electrical.ports[].AC.serviceShortCircuitBreakingCapacityIEC.value` |


### PR DESCRIPTION
Docs-only deliverable for DEV-9184.

Adds `iec-62683.md` at the repo root with:

- The IEC 62683 attribute list, grouped by the standard's property blocks (identification, general technical data, main circuit ratings, releases, connection, mounting, environmental, communication, certificates).
- A mapping table: IEC 62683 Attribute, Description, IDM key.
- Visible `(no IDM equivalent)` rows so the gaps are explicit.
- Fuse-specific and contactor/disconnect-specific mapping sections.

IDM keys are aligned to the rebuilt schema in PR #6 (branch `dev-9183-sync-interoperability-data-model-to-dcide-app-validators`), not to `main`. If PR #6 changes in review, the keys may need a refresh.

Sources: IEC 62683-1 public preview (block library and device class hierarchy) plus the IEC 60947-1 and IEC 60947-2 property base the standard references. The paywalled per-class property tables were not used; attributes that could not be confirmed were left out.

Linear: https://linear.app/dep/issue/DEV-9184

🤖